### PR TITLE
[WIP] Enable git_revision again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ ADD update.sh update.sh
 ADD deploykey.enc deploykey.enc
 ADD travisdeploykey.enc travisdeploykey.enc
 ADD scheduler.py scheduler.py
-#ADD .git/refs/heads/master git_revision
-RUN chown -R swuser:swuser planet update.sh deploykey.enc scheduler.py travisdeploykey.enc
+ADD .git/refs/heads/master git_revision
+RUN chown -R swuser:swuser planet update.sh deploykey.enc scheduler.py travisdeploykey.enc git_revision
 
 USER swuser
 

--- a/update.sh
+++ b/update.sh
@@ -31,6 +31,7 @@ COMMIT_MESSAGE="Publishing site on `date "+%Y-%m-%d %H:%M:%S"`"
 git checkout -t origin/gh-pages
 rm -rf *
 cp -r ../testrun/website/* .
+cp ../git_revision .
 if [[ "${TRAVIS}" != "true" ]]; then
     echo "planet.sympy.org" > CNAME
 fi


### PR DESCRIPTION
This fails for branches, since `.git/refs/heads/master` is not available for those.

We have to fix it by using `git` to save the commit hash to a file _before_ calling `docker build`, and in the `Dockerfile` just copy the file.
