### PR TITLE
Fix loading the site over https

### DIFF
--- a/planet/website/main.css
+++ b/planet/website/main.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Oxygen:400,700,300);
+@import url(https://fonts.googleapis.com/css?family=Oxygen:400,700,300);
 
 html{
     font-family: 'Oxygen', sans-serif;


### PR DESCRIPTION
This should fix mixed content warnings when loading the page over https.

I don't know how to test this, other than by merging it. CC @certik 

This is the full console log when loading https://planet.sympy.org:

```

﻿
(index):1 Mixed Content: The page at 'https://planet.sympy.org/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Oxygen:400,700,300'. This request has been blocked; the content must be served over HTTPS.
(index):24 Uncaught ReferenceError: applyConfig is not defined
    at (index):24
syndication.twitter.…pression%22%7D%7D:1 Failed to load resource: net::ERR_BLOCKED_BY_CLIENT
(index):51 Uncaught ReferenceError: applyConfig is not defined
    at onload ((index):51)
jot:1 Failed to load resource: net::ERR_BLOCKED_BY_CLIENT
(index):1 Mixed Content: The page at 'https://planet.sympy.org/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Oxygen:400,700,300'. This request has been blocked; the content must be served over HTTPS.
```