### PR TITLE
Add GitLab-CI for building the docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+image: docker:git
+
+services:
+  - docker:dind
+
+stages:
+  - build
+
+before_script:
+  - apk update
+  - apk add bash
+
+build_planet_sympy:
+  stage: build
+  script:
+    - bash build_image.sh

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+image_base_name=planet-sympy
+image_version=${CI_COMMIT_SHA:0:7}
+DNAME="$CI_REGISTRY_IMAGE:$image_base_name-$image_version"
+
+docker build -t "$DNAME" .
+
+docker push "$DNAME"


### PR DESCRIPTION
This automatically builds a Docker image from the latest master and uploads to
GitLab Docker registry.

The registry is here:

https://gitlab.com/sympy/planet-sympy/container_registry

The pipelines that build the docker image can be inspected here:

https://gitlab.com/sympy/planet-sympy/pipelines