### PR TITLE
Update blog link for GSoC specific blog

### DIFF
--- a/planet/planetsympy/config
+++ b/planet/planetsympy/config
@@ -546,7 +546,7 @@ feed 15m https://www.kangzhiq.com/tag/sympy/feed/
         define_facewidth 80
         define_faceheight 80
         
-feed 15m https://sc0rpi0n101.github.io/index.xml
+feed 15m https://sc0rpi0n101.github.io/categories/gsoc/index.xml
         define_name Nikhil Maan (Sc0rpi0n101)
         define_face hackergotchi/Nikhil_Maan.jpg
         define_facewidth 80


### PR DESCRIPTION
I have updated the blog RSS link to track only  project-specific feed so that planet-sympy does not have to deal with other unrelated blogs