### PR TITLE
Remove Blog Feed Link

### DIFF
--- a/planet/planetsympy/config
+++ b/planet/planetsympy/config
@@ -420,12 +420,6 @@ feed 15m http://ravicharann.github.io/blog/feed.xml
         define_facewidth 80
         define_faceheight 80
 
-feed 15m https://shikharj.github.io/feed.xml
-        define_name Shikhar Jaiswal (ShikharJ)
-        define_face hackergotchi/ShikharJ.jpg
-        define_facewidth 80
-        define_faceheight 80
-
 feed 15m https://valglad.github.io/feed.xml
         define_name Valeriia Gladkova (valglad)
         define_face hackergotchi/valglad.jpg


### PR DESCRIPTION
I recently started blogging again, and it is pretty unrelated to SymPy. So I wanted to remove my blog feed link to prevent pushing the posts to Planet SymPy as well.