### PR TITLE
removed PlanetSymp twitter ref, and added Sympy live shell button In place of twitter button

### DIFF
--- a/config/planet_template
+++ b/config/planet_template
@@ -67,7 +67,7 @@
                     </li>
                     <li><a href="#addmore" data-toggle="modal" data-target="#addmore">Add your Blog</a>
                     </li>
-                    <li><a href="#socfeeds" data-toggle="modal" data-target="#socfeeds">Twitter Feed</a>
+                    <li><a href="#hashtagsympy" data-toggle="modal" data-target="#hashtagsympy">Twitter Feed</a>
                     </li>
                     <li><a href="#hashtagsympy" data-toggle="modal" data-target="#hashtagsympy">#sympy</a>
                     </li>
@@ -76,7 +76,7 @@
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
                     <li>
-                        <a href="https://twitter.com/PlanetSymPy" id="donateLink">Follow @PlanetSymPy</a>
+                        <a href="https://live.sympy.org" id="donateLink">View SymPy Live</a>
                     </li>
                     <li>
                         <a href="http://www.sympy.org/en/donate.html" id="donateLink">Donate</a>
@@ -143,6 +143,7 @@
         </div>
     </div>
 
+    <!-- This hasnt been used, but i havent commented it out in case we want to use it later! -->
     <!-- Modal for Twitter Feed -->
     <div class="modal fade" id="socfeeds" tabindex="-1" role="dialog" aria-labelledby="socfeedsLabel">
         <div class="modal-dialog" role="document">


### PR DESCRIPTION
I have removed all references to PlanetSympy Twitter.
In the homepage nav, there was a big button navigating to twitter, I changed it to navigate to SymPy live, to make it meaningful and useful

* Fixes #121 


Let me know if any changes is needed.
Thank You!